### PR TITLE
Added the Krowi_WorldMapButtons lib

### DIFF
--- a/Libs/Krowi_WorldMapButtons-1.4/Krowi_WorldMapButtons-1.4.lua
+++ b/Libs/Krowi_WorldMapButtons-1.4/Krowi_WorldMapButtons-1.4.lua
@@ -1,0 +1,147 @@
+--[[
+	Krowi's World Map Buttons License
+		Copyright ©2020 The contents of this library, excluding third-party resources, are
+		copyrighted to their authors with all rights reserved.
+
+		This library is free to use and the authors hereby grants you the following rights:
+
+		1. 	You may make modifications to this library for private use only, you
+			may not publicize any portion of this library. The only exception being you may
+			upload to the github website.
+
+		2. 	Do not modify the name of this library, including the library folders.
+
+		3. 	This copyright notice shall be included in all copies or substantial
+			portions of the Software.
+
+		All rights not explicitly addressed in this license are reserved by
+		the copyright holders.
+]]
+
+local lib, oldminor = LibStub:NewLibrary('Krowi_WorldMapButtons-1.4', 7);
+
+if not lib then
+	return;
+end
+
+local version = (GetBuildInfo());
+local major = string.match(version, "(%d+)%.(%d+)%.(%d+)(%w?)");
+lib.IsClassic = major == "1";
+lib.IsTbcClassic = major == "2";
+lib.IsWrathClassic = major == "3";
+lib.HasNoOverlay = lib.IsClassic or lib.IsTbcClassic or lib.IsWrathClassic;
+lib.IsDragonflight = major == "10";
+lib.IsTheWarWithin = major == "11";
+lib.IsMainline = lib.IsDragonflight or lib.IsTheWarWithin;
+
+local AddButton;
+
+lib.XOffset, lib.YOffset = 4, -2;
+function lib:SetOffsets(xOffset, yOffset)
+	self.XOffset = xOffset or self.XOffset;
+	self.YOffset = yOffset or self.YOffset;
+end
+
+function lib.SetPoints()
+	local xOffset = lib.XOffset;
+	for _, button in next, lib.Buttons do
+		if button:IsShown() then
+			button:SetPoint("TOPRIGHT", button.relativeFrame, -xOffset, lib.YOffset);
+			xOffset = xOffset + 32;
+		end
+	end
+end
+
+local function HookDefaultButtons()
+	if WorldMapFrame.overlayFrames == nil then
+		lib.HookedDefaultButtons = true;
+		return;
+	end
+
+	for _, f in next, WorldMapFrame.overlayFrames do
+		if WorldMapTrackingOptionsButtonMixin and f.OnLoad == WorldMapTrackingOptionsButtonMixin.OnLoad then
+			f.KrowiWorldMapButtonsIndex = #lib.Buttons;
+			tinsert(lib.Buttons, f);
+		end
+		if WorldMapTrackingPinButtonMixin and f.OnLoad == WorldMapTrackingPinButtonMixin.OnLoad then
+			f.KrowiWorldMapButtonsIndex = #lib.Buttons;
+			tinsert(lib.Buttons, f);
+		end
+		if WorldMapShowLegendButtonMixin and f.OnLoad == WorldMapShowLegendButtonMixin.OnLoad then
+			f.KrowiWorldMapButtonsIndex = #lib.Buttons;
+			tinsert(lib.Buttons, f);
+		end
+	end
+
+	lib.HookedDefaultButtons = true;
+end
+
+local function PatchWrathClassic()
+	if lib.HasNoOverlay and WorldMapFrame.RefreshOverlayFrames == nil then
+		WorldMapFrame.RefreshOverlayFrames = function()
+		end
+	end
+
+	PatchWrathClassic = function() end;
+end
+
+function AddButton(button)
+	local xOffset = 4 + #lib.Buttons * 32;
+	button:SetPoint("TOPRIGHT", WorldMapFrame:GetCanvasContainer(), "TOPRIGHT", -xOffset, -2);
+	button.relativeFrame = WorldMapFrame:GetCanvasContainer();
+	hooksecurefunc(WorldMapFrame, lib.HasNoOverlay and "OnMapChanged" or "RefreshOverlayFrames", function()
+		button:Refresh();
+		lib.SetPoints();
+	end);
+
+	tinsert(lib.Buttons, button);
+
+	return button;
+end
+
+function lib:Add(templateName, templateType)
+	if self.Buttons == nil then
+		self.Buttons = {};
+	end
+
+	if not self.HookedDefaultButtons then
+		HookDefaultButtons();
+	end
+
+	PatchWrathClassic();
+
+	local button = CreateFrame(templateType, "Krowi_WorldMapButtons" .. (#self.Buttons + 1), lib.HasNoOverlay and WorldMapFrame.ScrollContainer or WorldMapFrame, templateName);
+
+	if lib.HasNoOverlay then
+		button:SetFrameStrata("TOOLTIP");
+	end
+
+	return AddButton(button);
+end
+
+-- handle upgrades
+
+if oldminor and oldminor == 1 then
+	lib.Buttons = lib.buttons;
+end
+
+if oldminor and oldminor == 3 then
+	if lib.HasNoOverlay then
+		for _, button in next, lib.Buttons do
+			button:SetParent(WorldMapFrame.ScrollContainer);
+			button:SetFrameStrata("TOOLTIP");
+		end
+	end
+end
+
+if oldminor and oldminor < 7 then
+	if lib.HookedDefaultButtons and WorldMapFrame.overlayFrames and WorldMapShowLegendButtonMixin then
+		-- Add the Legend button to the hooked set
+		for _, f in next, WorldMapFrame.overlayFrames do
+			if f.OnLoad == WorldMapShowLegendButtonMixin.OnLoad then
+				f.KrowiWorldMapButtonsIndex = #lib.Buttons;
+				tinsert(lib.Buttons, f);
+			end
+		end
+	end
+end

--- a/Libs/Krowi_WorldMapButtons-1.4/Krowi_WorldMapButtons-1.4.xml
+++ b/Libs/Krowi_WorldMapButtons-1.4/Krowi_WorldMapButtons-1.4.xml
@@ -1,0 +1,23 @@
+<!--
+	Krowi's World Map Buttons License
+		Copyright ©2020 The contents of this library, excluding third-party resources, are
+		copyrighted to their authors with all rights reserved.
+
+		This library is free to use and the authors hereby grants you the following rights:
+
+		1. 	You may make modifications to this library for private use only, you
+			may not publicize any portion of this library. The only exception being you may
+			upload to the github website.
+
+		2. 	Do not modify the name of this library, including the library folders.
+
+		3. 	This copyright notice shall be included in all copies or substantial
+			portions of the Software.
+
+		All rights not explicitly addressed in this license are reserved by
+		the copyright holders.
+ -->
+
+<Ui>
+	<Script file="Krowi_WorldMapButtons-1.4.lua"/>
+</Ui>

--- a/Libs/Krowi_WorldMapButtons-1.4/LICENSE
+++ b/Libs/Krowi_WorldMapButtons-1.4/LICENSE
@@ -1,0 +1,17 @@
+Krowi's World Map Buttons License
+	Copyright ©2020 The contents of this library, excluding third-party resources, are
+	copyrighted to their authors with all rights reserved.
+
+	This library is free to use and the authors hereby grants you the following rights:
+
+	1. 	You may make modifications to this library for private use only, you
+		may not publicize any portion of this library. The only exception being you may
+		upload to the github website.
+
+	2. 	Do not modify the name of this library, including the library folders.
+
+	3. 	This copyright notice shall be included in all copies or substantial
+		portions of the Software.
+
+	All rights not explicitly addressed in this license are reserved by
+	the copyright holders.

--- a/Libs/LibStub.lua
+++ b/Libs/LibStub.lua
@@ -1,0 +1,30 @@
+-- LibStub is a simple versioning stub meant for use in Libraries.  http://www.wowace.com/wiki/LibStub for more info
+-- LibStub is hereby placed in the Public Domain Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel, joshborke
+local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
+local LibStub = _G[LIBSTUB_MAJOR]
+
+if not LibStub or LibStub.minor < LIBSTUB_MINOR then
+	LibStub = LibStub or {libs = {}, minors = {} }
+	_G[LIBSTUB_MAJOR] = LibStub
+	LibStub.minor = LIBSTUB_MINOR
+
+	function LibStub:NewLibrary(major, minor)
+		assert(type(major) == "string", "Bad argument #2 to `NewLibrary' (string expected)")
+		minor = assert(tonumber(string.match(minor, "%d+")), "Minor version must either be a number or contain a number.")
+
+		local oldminor = self.minors[major]
+		if oldminor and oldminor >= minor then return nil end
+		self.minors[major], self.libs[major] = minor, self.libs[major] or {}
+		return self.libs[major], oldminor
+	end
+
+	function LibStub:GetLibrary(major, silent)
+		if not self.libs[major] and not silent then
+			error(("Cannot find a library instance of %q."):format(tostring(major)), 2)
+		end
+		return self.libs[major], self.minors[major]
+	end
+
+	function LibStub:IterateLibraries() return pairs(self.libs) end
+	setmetatable(LibStub, { __call = LibStub.GetLibrary })
+end

--- a/RecenterButtonTemplate.xml
+++ b/RecenterButtonTemplate.xml
@@ -1,11 +1,8 @@
-<Ui xmlns="http://www.blizzard.com/wow/ui/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/
-                        ..\FrameXML\UI.xsd">
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
 
-  <!-- Copied from WorldMapTrackingPinButtonTemplate (without scripts) -->
+  <!-- Copied from WorldMapTrackingPinButtonTemplate -->
   <!-- in Blizzard's \Interface\AddOns\Blizzard_WorldMap\Blizzard_WorldMapTemplates.xml -->
-  <Button name="RecenterButtonTemplate" frameStrata="HIGH" motionScriptsWhileDisabled="true" virtual="true">
+  <Button name="RecenterButtonTemplate" frameStrata="HIGH" motionScriptsWhileDisabled="true" enableMouse="true" virtual="true" mixin="PersistentWorldMapRecenterButtonMixin">
     <Size x="32" y="32"/>
 		<Layers>
 			<Layer level="BACKGROUND" textureSubLevel="-1">
@@ -54,11 +51,15 @@
 					<Size x="37" y="37"/>
 					<Anchors>
 						<Anchor point="TOPLEFT" relativeKey="$parent.Border" x="-2" y="1"/>
-					</Anchors>					
+					</Anchors>
 				</Texture>
-			</Layer>			
+			</Layer>
 		</Layers>
 		<HighlightTexture alphaMode="ADD" file="Interface\Minimap\UI-Minimap-ZoomButton-Highlight"/>
+		<Scripts>
+			<OnClick method="OnClick"/>
+			<OnEnter method="OnEnter"/>
+			<OnLeave function="GameTooltip_Hide"/>
+		</Scripts>
   </Button>
-  
 </Ui>

--- a/embeds.xml
+++ b/embeds.xml
@@ -1,0 +1,4 @@
+<Ui xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
+  <Script file="libs\LibStub.lua"/>
+  <Include file="libs\Krowi_WorldMapButtons-1.4\Krowi_WorldMapButtons-1.4.xml"/>
+</Ui>


### PR DESCRIPTION
I love the addon, but had an issue where the world map button was sitting on top of a button that HandyNotes was adding, due to the positioning being fixed to below the map pin button. I've integrated `Krowi_WorldMapButtons` which dynamically determines where to position the button, enabling the addon to play nicely with other addons that add buttons to the world map.